### PR TITLE
Use OP_LEGACY_SERVER_CONNECT on SSL contexts

### DIFF
--- a/noaweather/weathersource.py
+++ b/noaweather/weathersource.py
@@ -265,7 +265,12 @@ class GribDownloader(object):
             req.headers['Range'] = 'bytes=%d-%d' % (start, end)
 
         if hasattr(ssl, '_create_unverified_context'):
-            params = {'context': ssl._create_unverified_context()}
+            context = ssl._create_unverified_context()
+            if hasattr(ssl, 'OP_LEGACY_SERVER_CONNECT'):
+                context.options |= ssl.OP_LEGACY_SERVER_CONNECT
+            else:
+                context.options |= 4
+            params = {'context': context}
         else:
             params = {}
 


### PR DESCRIPTION
GFS download started to fail, and according to this: https://stackoverflow.com/questions/71603314/ssl-error-unsafe-legacy-renegotiation-disabled (see the second answer), setting the OP_LEGACY_SERVER_CONNECT option on the SSL context solves it. It indeed works (I am using Linux).